### PR TITLE
Fixed React-Hotloader AppContainer now uses children

### DIFF
--- a/source/client/entry.js
+++ b/source/client/entry.js
@@ -17,7 +17,7 @@ localStorage.removeItem('horizon-jwt');
 
 // Render application to target container
 ReactDOM.render(
-  <AppContainer component={Root} />,
+  <AppContainer ><Root /></AppContainer>,
   rootElement
 );
 


### PR DESCRIPTION
- Deprecation warning:
  Failed propType: Passing "component" prop to <AppContainer /> is deprecated. 
  Replace <AppContainer component={App} /> with <AppContainer><App /></AppContainer>.
