### PR TITLE
Fixing jobs on server by querying the table name from internal database

### DIFF
--- a/source/server/db.js
+++ b/source/server/db.js
@@ -1,6 +1,8 @@
 import rethinkdbdash from 'rethinkdbdash';
 import config from '../../config/db';
 
-const r = rethinkdbdash(config);
+export const r = rethinkdbdash(config);
 
-export default r;
+var config_internal = Object.assign({}, config);
+config_internal.db = config.db + '_internal';
+export const r_internal = rethinkdbdash(config_internal);

--- a/source/server/jobs/createTodos.js
+++ b/source/server/jobs/createTodos.js
@@ -1,5 +1,5 @@
 import later from 'later';
-import r from '../db';
+import { r, r_internal } from '../db';
 
 const todos = [
   'Bring out the trash.',
@@ -21,7 +21,10 @@ const todos = [
 
 const createRandomTodo = () => {
   const rand = Math.round(Math.random() * todos.length - 1, 0);
-  r.table('todos').insert({ text: todos[rand] }).run();
+  r_internal.table('collections').get('todos').run()
+  .then(function(result) {
+    r.table(result.table).insert({ text: todos[rand] }).run();
+  });
 };
 
 const every2minutes = later.parse.text('every 2 minutes');

--- a/source/server/jobs/deleteTodos.js
+++ b/source/server/jobs/deleteTodos.js
@@ -1,5 +1,5 @@
 import later from 'later';
-import r from '../db';
+import { r, r_internal } from '../db';
 
 /**
  * Delete all todos every 10 minutes.
@@ -8,7 +8,10 @@ import r from '../db';
 const every10minutes = later.parse.text('every 10 minutes');
 
 const deleteTodos = () => {
-  r.table('todos').delete().run();
+  r_internal.table('collections').get('todos').run()
+  .then(function(result) {
+    r.table(result.table).delete().run();
+  });
 };
 
 later.setInterval(deleteTodos, every10minutes);


### PR DESCRIPTION
It is still not possible to remove todo's from the UI. This is due to $hz_v$ being missing.
Issue about that here: https://github.com/flipace/lovli.js/issues/5

This will be fixxed when we are able to use the @horizon/client package.
Referencing @horizon/client still does not work when using a custom webpack setup.
There is a issue about this here: https://github.com/rethinkdb/horizon/issues/420.

This is PR is considered a temporary fix. Hopefully.
